### PR TITLE
Migration from music sync2inotify music processor

### DIFF
--- a/inotify_music_handler
+++ b/inotify_music_handler
@@ -1,16 +1,23 @@
 #!/bin/bash
 
+
 #+-------------------+
 #+---"Main Script"---+
 #+-------------------+
-inotifywait -m -r /media/Data_1/Audio/Music/FLAC_Backups -e create -e moved_to |
-  while read directory action file; do
-    if [[ "$file" =~ .*syncme$ ]]; then # Does the file end with .xml?
-      echo "dir is:$directory, action is:$action, file is:$file"
-      export SYNCME_SOURCE_DIR="$directory"
-      export SYNCME_ACTION="$action"
-      export SYNCME_FILE="$file"
-      echo "calling inotify_music_processor for autotagging"
-      /usr/local/bin/inotify_music_processor
-    fi
-  done
+verbosity=6
+while_type="NEW"
+source /usr/local/bin/helper_script.sh
+source /usr/local/bin/config.sh
+edebug "inotify_music_handler started"
+watch_folder="${flaclibrary_source%/*}"
+edebug "watch_folder will be $watch_folder"
+inotifywait -m -r "$watch_folder" -e create -e moved_to --format="%e %w%f" |
+while read -r action fullpath; do
+  if [[ "$fullpath" =~ .*syncme$ ]]; then # Does the file end with .syncme?
+    echo "action is:${action}, file is:${fullpath}, exporting now"
+    export SYNCME_SOURCE_DIR="${fullpath%/*}"
+    export SYNCME_ACTION="${action}"
+    export WHILE_TYPE="$while_type"
+    /usr/local/bin/inotify_music_processor
+  fi
+done

--- a/inotify_music_processor
+++ b/inotify_music_processor
@@ -3,20 +3,117 @@
 #+-------------------+
 #+---"Main Script"---+
 #+-------------------+
+verbosity=6
 source /usr/local/bin/helper_script.sh
-echo "inotify_music_processor called"
+source /usr/local/bin/config.sh
+edebug "inotify_music_processor called"
 #export SYNCME_SOURCE_DIR=$directory
 #export SYNCME_ACTION=$action
 #export SYNCME_FILE=$file
-echo "echo dir is:$SYNCME_SOURCE_DIR, action is:$SYNCME_ACTION, file is:$SYNCME_FILE"
-echo "Starting beets for autotagging"
-/home/emlyn/.local/bin/beet -c /home/emlyn/.config/beets/flac_tag_copy.yaml import -q /media/Data_1/Audio/Music/FLAC_Backups
-#echo "beets tagging completed"
-#if [ -z $dry_run_rsync ]; then
-#  echo "triggering KODI Music Server update..."
-#  update_musiclibrary #"Don't forget to set setting in advanced settings to have kodi mysql server 'clean' on update, or you will need to uncomment library clean""
-#  sleep 5m
-#  echo "...KODI Music Server library update complete"
-#fi
-#
-exit
+
+edebug "dir is:$SYNCME_SOURCE_DIR, action is:$SYNCME_ACTION, file is:$SYNCME_FILE"
+date_timestamp=$(/usr/bin/date "+%H%M_%y%m%d")
+
+#first handle (Albums) Unknown_Artist/Unknown_Album source to make uniquely identifiable and prevent abcde overwrite
+enotify "checking source location for Unknown_Artist/Unknown_Album or Various/Unknown_Album"
+if [[ "$SYNCME_SOURCE_DIR" == "${flaclibrary_source}Albums/Unknown_Artist/Unknown_Album/" ]]; then
+  action_type="singleartist"
+  einfo "Unknown (Artist) Album detected..."
+  edebug "...removing me.syncme to stop repeat inotify triggering"
+  if [ -f "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE" ]; then
+    rm "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE"
+    edebug "...removed"
+  fi
+  SYNCME_SOURCE_DIR_ORIGIN="$SYNCME_SOURCE_DIR" #assign the original path to another variable use in mv command
+  edebug "SYNCME_SOURCE_DIR_ORIGIN: $SYNCME_SOURCE_DIR_ORIGIN"
+  SYNCME_SOURCE_DIR=${SYNCME_SOURCE_DIR%/*} #this line and next...
+  if [[ "$action_type" == "singleartist" ]]; then
+    SYNCME_SOURCE_DIR=${SYNCME_SOURCE_DIR%/*} #...strip back variable to point to YOURDIR/Unknown_Artist
+  fi
+  edebug "SYNCME_SOURCE_DIR: $SYNCME_SOURCE_DIR"
+  edebug "...appending date_timestamp"
+  SYNCME_SOURCE_DIR="${SYNCME_SOURCE_DIR}_${date_timestamp}" #append Unknown_Album with stamp
+  edebug "SYNCME_SOURCE_DIR: $SYNCME_SOURCE_DIR"
+  edebug "making directory to move to: mkdir -p $SYNCME_SOURCE_DIR"
+  mkdir -p "${SYNCME_SOURCE_DIR}"
+  edebug "...moving un-unique: $SYNCME_SOURCE_DIR_ORIGIN $edebug to unique location: $SYNCME_SOURCE_DIR"
+  mv "$SYNCME_SOURCE_DIR_ORIGIN" "$SYNCME_SOURCE_DIR"
+  #tidy up hanging Unknown_Album folder
+  edebug "altering SYNCME_SOURCE_DIR_ORIGIN from: $SYNCME_SOURCE_DIR_ORIGIN ..."
+  SYNCME_SOURCE_DIR_ORIGIN=${SYNCME_SOURCE_DIR_ORIGIN%/*}
+  if [[ "$action_type" == "singleartist" ]]; then
+    SYNCME_SOURCE_DIR_ORIGIN=${SYNCME_SOURCE_DIR_ORIGIN%/*}
+  fi
+  edebug "...to $SYNCME_SOURCE_DIR_ORIGIN"
+  edebug "removing dangling folder $SYNCME_SOURCE_DIR_ORIGIN"
+  rm -r "$SYNCME_SOURCE_DIR_ORIGIN"
+  #sleep 62
+  SYNCME_SOURCE_DIR="${SYNCME_SOURCE_DIR}/Unknown_Album"
+  edebug "immediately prior to beets tagging SYNCME_SOURCE_DIR is: $SYNCME_SOURCE_DIR"
+elif [[ "$SYNCME_SOURCE_DIR" == "${flaclibrary_source}Various/Unknown_Album/" ]]; then ##next handle (Various/Soundtrack) Unknown_Album source to make uniquely identifiable
+  action_typw="variousartist"
+  edebug "Unknown (Various/Soundtrack) Album detected..."
+  edebug "...removing me.syncme to stop repeat inotify triggering"
+  if [ -f "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE" ]; then
+    rm "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE"
+    edebug "...removed"
+  fi
+  edebug "...appending date_timestamp"
+  SYNCME_SOURCE_DIR_ORIGIN="$SYNCME_SOURCE_DIR" #assign the original path to another variable use in mv command
+  edebug "SYNCME_SOURCE_DIR_ORIGIN: $SYNCME_SOURCE_DIR_ORIGIN"
+  SYNCME_SOURCE_DIR=${SYNCME_SOURCE_DIR%/*} #this line to strip back variable to point to YOURDIR/Unknown_Album
+  edebug "SYNCME_SOURCE_DIR: $SYNCME_SOURCE_DIR"
+  SYNCME_SOURCE_DIR="${SYNCME_SOURCE_DIR}_${date_timestamp}" #append Unknown_Album with stamp
+  edebug "SYNCME_SOURCE_DIR: $SYNCME_SOURCE_DIR"
+  edebug "making directory to move to: mkdir -p $SYNCME_SOURCE_DIR"
+  mkdir -p "${SYNCME_SOURCE_DIR}"
+  edebug "ammending SYNCME_SOURCE_DIR_ORIGIN to remove /"
+  SYNCME_SOURCE_DIR_ORIGIN=${SYNCME_SOURCE_DIR_ORIGIN%/*}
+  edebug "...moving un-unique: $SYNCME_SOURCE_DIR_ORIGIN $edebug to unique location: $SYNCME_SOURCE_DIR"
+  if [[ "$action_type" == "variousartist" ]]; then
+    cd "$SYNCME_SOURCE_DIR_ORIGIN" || error "SYNCME_SOURCE_DIR_ORIGIN could not be navigated too; variable shows as: $SYNCME_SOURCE_DIR_ORIGIN"
+    mv -- * "$SYNCME_SOURCE_DIR"
+    cd ../
+    #tidy up hanging Unknown_Album folder
+    rm -r "$SYNCME_SOURCE_DIR_ORIGIN"
+    #sleep 62
+  fi
+  edebug "immediately prior to beets tagging SYNCME_SOURCE_DIR is: $SYNCME_SOURCE_DIR"
+fi
+
+
+#begin autotagging
+edebug "Starting beets for autotagging..."
+##"$beets_path" -c /home/emlyn/.config/beets/flac_tag_copy.yaml import -q /media/Data_1/Audio/Music/FLAC_Backups
+##"$beets_path" -c /home/emlyn/.config/beets/flac_tag_copy.yaml import -q "$SYNCME_SOURCE_DIR"
+
+#check first if manual override
+if [[ -f "${SYNCME_SOURCE_DIR}/picard.id" ]]; then
+  picard_id=$(<"${SYNCME_SOURCE_DIR}/picard.id")
+  enotify "found picard.id file, manual import selected; importing ID:${picard_id}"
+  "$beets_path" -c "/home/jlivin25/.config/beets/flac_tag_copy.yaml" import -q --flat --search-id "$picard_id" "$SYNCME_SOURCE_DIR"
+  rm "${SYNCME_SOURCE_DIR}/picard.id"
+else
+  edebug "...no manual override detected, proceeding in automatic mode"
+  "$beets_path" -c /home/jlivin25/.config/beets/flac_tag_copy.yaml import -q "$SYNCME_SOURCE_DIR"
+fi
+
+
+#check next for skipping from beets
+if [[ $(tail -n 1 ~/.config/beets/beetslog.txt | cut -d " " -f 1) == "duplicate-skip" ]] || [[ $(tail -n 1 ~/.config/beets/beetslog.txt | cut -d " " -f 1) == "skip" ]]; then
+  #ewarn "Detected beets skipping, manual input required, to investigate please navigate to: $(tail -n 1 ~/.config/beets/beetslog.txt | cut -d " " -f 2)"
+  ewarn "Detected beets skipping, manual input required, to investigate please navigate to: $(tail -n 1 ~/.config/beets/beetslog.txt | cut -d " " -f 2 | cut -d "/" -f -8)"
+else
+  edebug "...beets tagging completed"
+fi
+
+
+#finish off
+if [ -f "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE" ]; then
+  edebug "sycnme file detected, removing..."
+  rm "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE"
+  edebug "...removed"
+fi
+enotify "script completed"
+
+exit 0

--- a/inotify_music_processor
+++ b/inotify_music_processor
@@ -1,34 +1,181 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-#+-------------------+
-#+---"Main Script"---+
-#+-------------------+
-verbosity=6
+# (C) 2022 littlejeem
+# https://github.com/littlejeem
+
+# This code is licensed under MIT license:
+# http://opensource.org/licenses/MIT
+
+# Shell Style Guide have been adhered to where viable
+# https://google.github.io/styleguide/shell.xml
+# and
+# https://tldp.org/LDP/abs/html/index.html
+
+# Linted with shellcheck: https://github.com/koalaman/shellcheck
+
+# Developed using Atom: https://atom.io/
+
+# References:
+# HERE IF APLICABLE
+
+# Credits
+# Thank you to anyone who has made script, posted on stackexchange or posted a blog thats influenced me,
+# if i've used something and not credited message me and I'll add it. ta!
+
+# DISCLAIMER
+# Whilst care has been taken to thoroughly test this script, my knowledge is currently limited to Ubuntu
+# cases, # as with all Linux/UNIX-like affairs, it may still fail in mysterious
+# circumstances. I'M STILL A NEWB!
+
+#########################################################################
+###    "PUT INFO ABOUT THE SCRIPT, ITS PURPOSE, HOW IT WORKS"         ###
+###      "WHERE IT SHOULD BE KEPT, DEPENDANCIES, etc...here"          ###
+#########################################################################
+
+#+--------------------------------------+
+#+---"Exit Codes & Logging Verbosity"---+
+#+--------------------------------------+
+# Exit codes:
+# pick from 64 - 113 (https://tldp.org/LDP/abs/html/exitcodes.html#FTN.AEN23647)
+# exit 0 = Success
+# exit 64 = Variable Error
+# exit 65 = Sourcing file/folder error
+# exit 66 = Processing Error
+# exit 67 = Required Program Missing
+
+# Verbosity levels
+# silent_lvl=0
+# crt_lvl=1
+# err_lvl=2
+# wrn_lvl=3
+# ntf_lvl=4
+# inf_lvl=5
+# dbg_lvl=6
+
+
+#+----------------------+
+#+---"Notes on style"---+
+#+----------------------+
+# Use one return to seperate chunks of code from each other
+# Use two returns to seperate sections in the script
+# Use #+------+ to header sections
+# Use ########
+#     ###  ###
+#     ######## to indicate important fill-in sections
+
+# Two spaces to indent, NOT TABS!
+
+# don't echo "" or echo -e "" for a blank line, use echo -e "\r" or echo -e "\n"
+# edebug "\r" or equivalent will also work
+
+# Todo example
+# TODO(littlejeem): Handle the unlikely edge cases (bug ####)
+
+# Google style guide states that a function uses the format 'function name () {' style to declare a function
+# but commonly accepted practice is that function is no longer used and depricated so plain 'name () {'
+# Use comments to describe inobvious functions, example below
+
+#######################################
+# Cleanup files from the backup directory.
+# Globals:
+#   BACKUP_DIR
+#   ORACLE_SID
+# Arguments:
+#   None
+#######################################
+
+# the help function in this file needs no comments as its usage is straight forward
+
+
+#+----------------------+
+#+---"Check for Root"---+
+#+----------------------+
+#only needed if root privaleges necessary, enable
+#if [[ $EUID -ne 0 ]]; then
+#    echo "Please run this script with sudo:"
+#    echo "sudo $0 $*"
+#    exit 66
+#fi
+#
+#
+#+-----------------------+
+#+---"Set script name"---+
+#+-----------------------+
+# imports the name of this script
+# failure to to set this as lockname will result in check_running failing and 'hung' script
+# manually set this if being run as child from another script otherwise will inherit name of calling/parent script
+scriptlong=$(basename "$0")
+#test to see if ends in .sh, if so remove
+if [[ "${scriptlong#"${scriptlong%???}"}" == ".sh" ]]; then
+  lockname=${scriptlong::-3}
+else
+  lockname="$scriptlong"
+fi
+
+
+#+---------------------------------------+
+#+---Source necessary 'helper' scripts---+
+#+---------------------------------------+
 source /usr/local/bin/helper_script.sh
 source /usr/local/bin/config.sh
-edebug "inotify_music_processor called"
+
+
+#+---------------------+
+#+---"Set Variables"---+
+#+---------------------+
+#set default logging level, failure to set this will cause a 'unary operator expected' error
+#remember at level 3 and lower, only esilent messages show, best to include an override in getopts
+verbosity=3
+#
+version="0.4" #
+script_pid=$(echo $$)
+#TODO(littlejeem): Look here at usage of backtics
+date_timestamp=$(/usr/bin/date "+%H%M_%y%m%d")
+notify_lock=/tmp/IPChecker_notify
+pushover_title="inotify_music_processor" #Uncomment if using pushover
+SYNCME_SOURCE_DIR="${SYNCME_SOURCE_DIR}/"
 #export SYNCME_SOURCE_DIR=$directory
 #export SYNCME_ACTION=$action
 #export SYNCME_FILE=$file
+application_token="$inotify_processor_app_token"
 
-edebug "dir is:$SYNCME_SOURCE_DIR, action is:$SYNCME_ACTION, file is:$SYNCME_FILE"
-date_timestamp=$(/usr/bin/date "+%H%M_%y%m%d")
 
-#first handle (Albums) Unknown_Artist/Unknown_Album source to make uniquely identifiable and prevent abcde overwrite
-enotify "checking source location for Unknown_Artist/Unknown_Album or Various/Unknown_Album"
-if [[ "$SYNCME_SOURCE_DIR" == "${flaclibrary_source}Albums/Unknown_Artist/Unknown_Album/" ]]; then
+#+-------------------+
+#+---Set functions---+
+#+-------------------+
+helpFunction () {
+   echo ""
+   echo "Usage: $0 $scriptlong"
+   echo "Usage: $0 $scriptlong -G"
+   echo -e "\t Running the script with no flags causes default behaviour with logging level set via 'verbosity' variable"
+   echo -e "\t-S Override set verbosity to specify silent log level"
+   echo -e "\t-V Override set verbosity to specify Verbose log level"
+   echo -e "\t-G Override set verbosity to specify Debug log level"
+   echo -e "\t-h Use this flag for help"
+   if [ -d "/tmp/$lockname" ]; then
+     edebug "removing lock directory"
+     rm -r "/tmp/$lockname"
+   else
+     edebug "problem removing lock directory"
+   fi
+   exit 65 # Exit script after printing help
+}
+
+#TODO @littlejeem: Possible to use 'action_type' to diffrentiate sections and therefore combine functions?
+single_artist_process () {
   action_type="singleartist"
+  edebug "action_type detected as $action_type"
   einfo "Unknown (Artist) Album detected..."
   edebug "...removing me.syncme to stop repeat inotify triggering"
   if [ -f "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE" ]; then
-    rm "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE"
-    edebug "...removed"
+      rm "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE"
+      edebug "...removed"
   fi
   SYNCME_SOURCE_DIR_ORIGIN="$SYNCME_SOURCE_DIR" #assign the original path to another variable use in mv command
   edebug "SYNCME_SOURCE_DIR_ORIGIN: $SYNCME_SOURCE_DIR_ORIGIN"
   SYNCME_SOURCE_DIR=${SYNCME_SOURCE_DIR%/*} #this line and next...
   if [[ "$action_type" == "singleartist" ]]; then
-    SYNCME_SOURCE_DIR=${SYNCME_SOURCE_DIR%/*} #...strip back variable to point to YOURDIR/Unknown_Artist
+      SYNCME_SOURCE_DIR=${SYNCME_SOURCE_DIR%/*} #...strip back variable to point to YOURDIR/Unknown_Artist
   fi
   edebug "SYNCME_SOURCE_DIR: $SYNCME_SOURCE_DIR"
   edebug "...appending date_timestamp"
@@ -42,21 +189,24 @@ if [[ "$SYNCME_SOURCE_DIR" == "${flaclibrary_source}Albums/Unknown_Artist/Unknow
   edebug "altering SYNCME_SOURCE_DIR_ORIGIN from: $SYNCME_SOURCE_DIR_ORIGIN ..."
   SYNCME_SOURCE_DIR_ORIGIN=${SYNCME_SOURCE_DIR_ORIGIN%/*}
   if [[ "$action_type" == "singleartist" ]]; then
-    SYNCME_SOURCE_DIR_ORIGIN=${SYNCME_SOURCE_DIR_ORIGIN%/*}
+      SYNCME_SOURCE_DIR_ORIGIN=${SYNCME_SOURCE_DIR_ORIGIN%/*}
   fi
   edebug "...to $SYNCME_SOURCE_DIR_ORIGIN"
   edebug "removing dangling folder $SYNCME_SOURCE_DIR_ORIGIN"
+  #TODO @littlejeem: add in safeguards for 'empty variables both at script start and during?'
   rm -r "$SYNCME_SOURCE_DIR_ORIGIN"
-  #sleep 62
   SYNCME_SOURCE_DIR="${SYNCME_SOURCE_DIR}/Unknown_Album"
-  edebug "immediately prior to beets tagging SYNCME_SOURCE_DIR is: $SYNCME_SOURCE_DIR"
-elif [[ "$SYNCME_SOURCE_DIR" == "${flaclibrary_source}Various/Unknown_Album/" ]]; then ##next handle (Various/Soundtrack) Unknown_Album source to make uniquely identifiable
-  action_typw="variousartist"
+}
+
+various_artist_process () {
+  action_type="variousartist"
+  edebug "action_type detected as $action_type"
   edebug "Unknown (Various/Soundtrack) Album detected..."
   edebug "...removing me.syncme to stop repeat inotify triggering"
-  if [ -f "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE" ]; then
-    rm "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE"
-    edebug "...removed"
+  #TODO @littlejeem: Need to make the risk of lone '/' safer
+  if [[ -f "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE" ]]; then
+      rm "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE"
+      edebug "...removed"
   fi
   edebug "...appending date_timestamp"
   SYNCME_SOURCE_DIR_ORIGIN="$SYNCME_SOURCE_DIR" #assign the original path to another variable use in mv command
@@ -69,51 +219,191 @@ elif [[ "$SYNCME_SOURCE_DIR" == "${flaclibrary_source}Various/Unknown_Album/" ]]
   mkdir -p "${SYNCME_SOURCE_DIR}"
   edebug "ammending SYNCME_SOURCE_DIR_ORIGIN to remove /"
   SYNCME_SOURCE_DIR_ORIGIN=${SYNCME_SOURCE_DIR_ORIGIN%/*}
-  edebug "...moving un-unique: $SYNCME_SOURCE_DIR_ORIGIN $edebug to unique location: $SYNCME_SOURCE_DIR"
+  edebug "...moving un-unique: $SYNCME_SOURCE_DIR_ORIGIN to unique location: $SYNCME_SOURCE_DIR"
   if [[ "$action_type" == "variousartist" ]]; then
-    cd "$SYNCME_SOURCE_DIR_ORIGIN" || error "SYNCME_SOURCE_DIR_ORIGIN could not be navigated too; variable shows as: $SYNCME_SOURCE_DIR_ORIGIN"
-    mv -- * "$SYNCME_SOURCE_DIR"
-    cd ../
-    #tidy up hanging Unknown_Album folder
-    rm -r "$SYNCME_SOURCE_DIR_ORIGIN"
-    #sleep 62
+      cd "$SYNCME_SOURCE_DIR_ORIGIN" || eerror "SYNCME_SOURCE_DIR_ORIGIN could not be navigated too; variable shows as: $SYNCME_SOURCE_DIR_ORIGIN"
+      #TODO @littlejeem: Need to make the mv command safer
+      mv -- * "$SYNCME_SOURCE_DIR"
+      cd ../
+      #tidy up hanging Unknown_Album folder
+      rm -r "$SYNCME_SOURCE_DIR_ORIGIN"
   fi
+}
+
+beets_autotagging () {
   edebug "immediately prior to beets tagging SYNCME_SOURCE_DIR is: $SYNCME_SOURCE_DIR"
-fi
+  #begin autotagging
+  edebug "Starting beets for autotagging..."
+  #check first if manual override
+  if [[ -f "${SYNCME_SOURCE_DIR}/picard.id" ]]; then
+    picard_id=$(<"${SYNCME_SOURCE_DIR}/picard.id")
+    enotify "found picard.id file, manual import selected; importing ID:${picard_id}"
+    "$beets_path" -c "${beets_config_path}/flac_tag_copy.yaml" import -q --flat --search-id "$picard_id" "$SYNCME_SOURCE_DIR" > /dev/null
+    rm "${SYNCME_SOURCE_DIR}/picard.id"
+  else
+    edebug "...no manual override detected, proceeding in automatic mode"
+    "$beets_path" -c "${beets_config_path}/flac_tag_copy.yaml" import -q "$SYNCME_SOURCE_DIR" > /dev/null
+  fi
+}
 
-
-#begin autotagging
-edebug "Starting beets for autotagging..."
-##"$beets_path" -c /home/emlyn/.config/beets/flac_tag_copy.yaml import -q /media/Data_1/Audio/Music/FLAC_Backups
-##"$beets_path" -c /home/emlyn/.config/beets/flac_tag_copy.yaml import -q "$SYNCME_SOURCE_DIR"
-
-#check first if manual override
-if [[ -f "${SYNCME_SOURCE_DIR}/picard.id" ]]; then
-  picard_id=$(<"${SYNCME_SOURCE_DIR}/picard.id")
-  enotify "found picard.id file, manual import selected; importing ID:${picard_id}"
-  "$beets_path" -c "/home/jlivin25/.config/beets/flac_tag_copy.yaml" import -q --flat --search-id "$picard_id" "$SYNCME_SOURCE_DIR"
-  rm "${SYNCME_SOURCE_DIR}/picard.id"
-else
-  edebug "...no manual override detected, proceeding in automatic mode"
-  "$beets_path" -c /home/jlivin25/.config/beets/flac_tag_copy.yaml import -q "$SYNCME_SOURCE_DIR"
-fi
-
-
-#check next for skipping from beets
-if [[ $(tail -n 1 ~/.config/beets/beetslog.txt | cut -d " " -f 1) == "duplicate-skip" ]] || [[ $(tail -n 1 ~/.config/beets/beetslog.txt | cut -d " " -f 1) == "skip" ]]; then
-  #ewarn "Detected beets skipping, manual input required, to investigate please navigate to: $(tail -n 1 ~/.config/beets/beetslog.txt | cut -d " " -f 2)"
-  ewarn "Detected beets skipping, manual input required, to investigate please navigate to: $(tail -n 1 ~/.config/beets/beetslog.txt | cut -d " " -f 2 | cut -d "/" -f -8)"
+beets_skip_check () {
+if [[ $(tail -n 1 ${beets_config_path}/beetslog.txt | cut -d " " -f 1) == "duplicate-skip" ]] || [[ $(tail -n 1 ${beets_config_path}/beetslog.txt | cut -d " " -f 1) == "skip" ]]; then
+  skip_folder=$(tail -n 1 ${beets_config_path}/beetslog.txt)
+  skip_folder=${skip_folder%/*}
+  if [[ "$action_type" == "singleartist" ]]; then
+    skip_folder=${skip_folder%/*}
+    skip_folder=${skip_folder%/*}
+  fi
+  ewarn "Detected beets skipping, manual input required, to investigate please navigate to: $skip_folder"
+  pushover_folder=${skip_folder##*/}
+  message_form="Detected beets skipping, navigate to your rip folder/${pushover_folder}"
+  pushover
 else
   edebug "...beets tagging completed"
 fi
+}
+
+beets_tidy () {
+  if [ -f "${SYNCME_SOURCE_DIR}/me.syncme" ]; then
+    edebug "sycnme file detected, removing..."
+    rm "${SYNCME_SOURCE_DIR}/me.syncme"
+    edebug "...removed"
+  fi
+}
+
+clean_ctrlc () {
+  let ctrlc_count++
+  if [[ $ctrlc_count == 1 ]]; then
+    echo "Quit command detected, are you sure?"
+  elif [[ $ctrlc_count == 2 ]]; then
+    echo "...once more and the script will exit..."
+  else
+    echo "...exiting script."
+    if [ -d "/tmp/$lockname" ]; then
+      edebug "removing lock directory"
+      rm -r "/tmp/$lockname"
+    else
+      edebug "problem removing lock directory"
+    fi
+  fi
+  exit 66
+}
+
+clean_exit () {
+  if [ -d "/tmp/$lockname" ]; then
+    edebug "removing lock directory"
+    rm -r "/tmp/$lockname"
+  else
+    edebug "problem removing lock directory"
+  fi
+  esilent "$lockname completed"
+  exit 0
+}
 
 
-#finish off
-if [ -f "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE" ]; then
-  edebug "sycnme file detected, removing..."
-  rm "$SYNCME_SOURCE_DIR"/"$SYNCME_FILE"
-  edebug "...removed"
+#+------------------------+
+#+---"Get User Options"---+
+#+------------------------+
+OPTIND=1
+while getopts ":SVGHh:" opt
+do
+    case "${opt}" in
+        S) verbosity=$silent_lvl
+        edebug "-S specified: Silent mode";;
+        V) verbosity=$inf_lvl
+        edebug "-V specified: Verbose mode";;
+        G) verbosity=$dbg_lvl
+        edebug "-G specified: Debug mode";;
+        H) helpFunction;;
+        h) helpFunction;;
+        ?) helpFunction;;
+    esac
+done
+shift $((OPTIND -1))
+
+
+#+---------------------+
+#+---"Trap & ctrl-c"---+
+#+---------------------+
+#SIGINT, SIGTERM, or SIGHUP
+trap clean_ctrlc SIGINT
+trap clean_exit SIGTERM
+ctrlc_count=0
+
+
+#+---------------------------------------+
+#+---"check if script already running"---+
+#+---------------------------------------+
+check_running
+
+
+#+----------------------+
+#+---"Script Started"---+
+#+----------------------+
+# At this point the script is set up and all necessary conditions met so lets log this
+esilent "$scriptlong started"
+esilent "inotify_music_processor called from inotify_music_monitor"
+
+
+#+--------------------------------------+
+#+---"Display some info about script"---+
+#+--------------------------------------+
+edebug "Version of $scriptlong is: $version"
+edebug "Version of helper_script is: $helper_version"
+edebug "PID is $script_pid"
+
+
+#+-------------------+
+#+---Set up script---+
+#+-------------------+
+#Get environmental info
+edebug "INVOCATION_ID is set as: $INVOCATION_ID"
+edebug "EUID is set as: $EUID"
+edebug "PATH is: $PATH"
+
+
+#+----------------------------+
+#+---"Main Script Contents"---+
+#+----------------------------+
+edebug "dir is:$SYNCME_SOURCE_DIR, action is:$SYNCME_ACTION"
+date_timestamp=$(/usr/bin/date "+%H%M_%y%m%d")
+
+#first handle (Albums) Unknown_Artist/Unknown_Album source to make uniquely identifiable and prevent abcde overwrite
+enotify "checking source location for Unknown_Artist/Unknown_Album or Various/Unknown_Album"
+#TODO @littlejeem: add in detection for whote spaced Unknown Album as well as existing Unknown_Album'
+if [[ "$SYNCME_SOURCE_DIR" == "${flaclibrary_source}Albums/Unknown_Artist/Unknown_Album/" ]]; then
+  single_artist_process
+  #check for manual override, else process as is
+  beets_autotagging
+  #check skipping
+  beets_skip_check
+  #remove me.sycme
+  beets_tidy
+  #finish script
+  clean_exit
 fi
-enotify "script completed"
 
-exit 0
+##next handle (Various/Soundtrack) Unknown_Album source to make uniquely identifiable
+#TODO @littlejeem: add in detection for whote spaced Unknown Album as well as existing Unknown_Album'
+if [[ "$SYNCME_SOURCE_DIR" == "${flaclibrary_source}Various/Unknown_Album/" ]]; then
+  various_artist_process
+  beets_autotagging
+  #check skipping
+  beets_skip_check
+  #remove me.sycme
+  beets_tidy
+  #finish script
+  clean_exit
+fi
+
+action_type="normal"
+edebug "action_type detected as $action_type"
+#if niether of the above processes hold true then proceed with tagging folder as found.
+#check for manual override, else process as is
+beets_autotagging
+#check skipping
+beets_skip_check
+#remove me.sycme
+beets_tidy
+#finish script
+clean_exit


### PR DESCRIPTION
initial work to create a useable script based on systemd 'd' watcher allowing a 'handler' script to detect presence of a named file and trigger the necessary 'processor' script to utilise beets for tagging. Various handiling of edge cases that can't be tagged and integration of ability to manually override autodetection be providing a musicbrainz id in a file